### PR TITLE
Feature/mlx swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "620777d4f47a191570d5624106afe0092dbd2f3d8e0cb04452ff23baab5fe8c3",
+  "originHash" : "e78e4a9d159cf7c39d9a6f130931d98a2a292af8cbea6fd940cad7c5293fe3fe",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -47,12 +47,39 @@
       }
     },
     {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift",
+      "state" : {
+        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
+        "version" : "6.0.1"
+      }
+    },
+    {
       "identity" : "llama.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/llama.swift",
       "state" : {
         "revision" : "041c2e821e9b3cebcd4fb2a0d1b59142742fe88b",
         "version" : "2.9874.0"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
+        "version" : "0.29.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift-examples",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-examples",
+      "state" : {
+        "revision" : "9bff95ca5f0b9e8c021acc4d71a2bbe4a7441631",
+        "version" : "2.29.1"
       }
     },
     {
@@ -164,6 +191,15 @@
       }
     },
     {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -260,6 +296,15 @@
       "state" : {
         "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
         "version" : "1.7.2"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "a2e184dddb4757bc943e77fbe99ac6786c53f0b2",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,8 @@ let package = Package(
         .package(url: "https://github.com/mattt/llama.swift", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.88.0"),
         .package(url: "https://github.com/apple/containerization.git", from: "0.36.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift", from: "0.29.0"),
+        .package(url: "https://github.com/ml-explore/mlx-swift-examples", from: "2.29.0"),
     ],
     targets: [
         .target(
@@ -19,6 +21,9 @@ let package = Package(
                 .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationOCI", package: "containerization"),
+                .product(name: "MLX", package: "mlx-swift"),
+                .product(name: "MLXLLM", package: "mlx-swift-examples"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-examples"),
             ],
             resources: [.copy("Resources")]),
         .executableTarget(

--- a/Sources/Hedos/PixelType.swift
+++ b/Sources/Hedos/PixelType.swift
@@ -116,16 +116,16 @@ struct HedosWordmark: View {
                 cursor += unit * 6
             }
         }
-        .frame(width: unit * CGFloat(text.count) * 6, height: unit * 7)
+        .frame(width: unit * CGFloat(text.count) * 6, height: unit * 6)
         .accessibilityLabel("hedos")
     }
 
     static let glyphs: [Character: [[Character]]] = [
-        "h": ["10000", "10000", "10000", "11110", "10010", "10010", "10010"].map(Array.init),
-        "e": ["00000", "00000", "01100", "10010", "11110", "10000", "01110"].map(Array.init),
-        "d": ["00010", "00010", "00010", "01110", "10010", "10010", "01110"].map(Array.init),
-        "o": ["00000", "00000", "01100", "10010", "10010", "10010", "01100"].map(Array.init),
-        "s": ["00000", "00000", "01110", "10000", "01100", "00010", "11100"].map(Array.init),
+        "h": ["10000", "10000", "11110", "10010", "10010", "10010"].map(Array.init),
+        "e": ["00000", "01100", "10010", "11110", "10000", "01110"].map(Array.init),
+        "d": ["00010", "00010", "01110", "10010", "10010", "01110"].map(Array.init),
+        "o": ["00000", "01100", "10010", "10010", "10010", "01100"].map(Array.init),
+        "s": ["00000", "01110", "10000", "01100", "00010", "11100"].map(Array.init),
     ]
 }
 

--- a/Sources/HedosKernel/Kernel.swift
+++ b/Sources/HedosKernel/Kernel.swift
@@ -112,6 +112,7 @@ public actor Kernel {
             MlxAudioAdapter(governor: governor),
             MfluxAdapter(governor: governor),
             DiffusersAdapter(governor: governor),
+            MlxSwiftAdapter(governor: governor),
             MlxLmAdapter(governor: governor),
             AppleFoundationAdapter(registry: registry),
             OpenAIEndpointAdapter(secrets: secrets, registry: registry),

--- a/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftAdapter.swift
+++ b/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftAdapter.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+public struct MlxSwiftAdapter: RuntimeAdapter {
+    public var id: String { "mlx-swift" }
+
+    private let governor: MemoryGovernor
+
+    public init(governor: MemoryGovernor = .shared) {
+        self.governor = governor
+    }
+
+    static func params(from object: [String: JSONValue]) -> MlxSwiftEngine.GenerationParams {
+        var params = MlxSwiftEngine.GenerationParams()
+        if let temperature = object["temperature"]?.doubleValue {
+            params.temperature = Float(temperature)
+        }
+        if let topP = object["top_p"]?.doubleValue {
+            params.topP = Float(topP)
+        }
+        if let maxTokens = object["max_tokens"]?.intValue, maxTokens > 0 {
+            params.maxTokens = maxTokens
+        }
+        return params
+    }
+
+    public func canServe(_ record: ModelRecord, _ capability: Capability) -> Bool {
+        guard capability == .chat || capability == .complete else { return false }
+        if let runtimeID = record.runtime.id { return runtimeID == id }
+        return false
+    }
+
+    public func bid(_ record: ModelRecord, _ identified: IdentifiedModel) -> RuntimeBid? {
+        guard identified.format == .mlxSafetensors,
+            identified.modality == .text,
+            identified.capabilities.contains(.chat)
+        else { return nil }
+        return RuntimeBid(tier: .native, preference: 15, alternatives: [])
+    }
+
+    public func invoke(
+        _ record: ModelRecord, _ capability: Capability, payload: JSONValue
+    ) -> AsyncThrowingStream<CapabilityChunk, Error> {
+        AsyncThrowingStream { continuation in
+            guard case .object(let object) = payload,
+                case .array(let rawMessages)? = object["messages"]
+            else {
+                continuation.finish(
+                    throwing: KernelError.runtimeFailed("chat payload must carry messages"))
+                return
+            }
+            let messages = rawMessages.compactMap { value -> ChatMessage? in
+                guard case .object(let fields) = value,
+                    case .string(let role)? = fields["role"],
+                    case .string(let content)? = fields["content"],
+                    let parsedRole = ChatMessage.Role(rawValue: role)
+                else { return nil }
+                return ChatMessage(role: parsedRole, content: content)
+            }
+            let directory = SidecarModelPaths.resolve(record).snapshot
+            let governor = governor
+            let params = Self.params(from: object)
+            let task = Task {
+                await MlxSwiftEngine.shared.run(
+                    path: directory,
+                    modelID: record.id,
+                    modelName: record.name,
+                    footprintMB: record.footprintMB,
+                    governor: governor,
+                    messages: messages,
+                    params: params,
+                    continuation: continuation)
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+}

--- a/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftEngine.swift
+++ b/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftEngine.swift
@@ -1,0 +1,247 @@
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+
+public actor MlxSwiftEngine {
+    public static let shared = MlxSwiftEngine()
+
+    private var loadedPath: String?
+    private var loadedModelID: String?
+    private var container: ModelContainer?
+    private var generationSlotHeld = false
+    private var generationSlotWaiters: [CheckedContinuation<Void, Never>] = []
+
+    public struct GenerationParams: Sendable {
+        public var temperature: Float
+        public var topP: Float?
+        public var maxTokens: Int
+
+        public init(temperature: Float = 0.7, topP: Float? = nil, maxTokens: Int = 2048) {
+            self.temperature = temperature
+            self.topP = topP
+            self.maxTokens = maxTokens
+        }
+    }
+
+    public func run(
+        path: String,
+        modelID: String,
+        modelName: String,
+        footprintMB: Int?,
+        governor: MemoryGovernor,
+        messages: [ChatMessage],
+        params: GenerationParams = GenerationParams(),
+        continuation: AsyncThrowingStream<CapabilityChunk, Error>.Continuation
+    ) async {
+        await governor.beginGeneration(modelID)
+        await acquireGenerationSlot()
+        do {
+            let producer = GPUProducer.generation(modelID: modelID)
+            try await acquireGateWithModelLoaded(
+                producer: producer, path: path, modelID: modelID, modelName: modelName,
+                footprintMB: footprintMB, governor: governor, continuation: continuation)
+            do {
+                try await generate(messages: messages, params: params, continuation: continuation)
+                MLX.Stream().synchronize()
+                await governor.gate.release(producer)
+            } catch {
+                MLX.Stream().synchronize()
+                await governor.gate.release(producer)
+                throw error
+            }
+            continuation.finish()
+        } catch {
+            continuation.finish(throwing: error)
+        }
+        releaseGenerationSlot()
+        await governor.endGeneration(modelID)
+    }
+
+    private func acquireGenerationSlot() async {
+        if !generationSlotHeld {
+            generationSlotHeld = true
+            return
+        }
+        await withCheckedContinuation { generationSlotWaiters.append($0) }
+    }
+
+    private func releaseGenerationSlot() {
+        if generationSlotWaiters.isEmpty {
+            generationSlotHeld = false
+        } else {
+            generationSlotWaiters.removeFirst().resume()
+        }
+    }
+
+    private func acquireGateWithModelLoaded(
+        producer: GPUProducer,
+        path: String,
+        modelID: String,
+        modelName: String,
+        footprintMB: Int?,
+        governor: MemoryGovernor,
+        continuation: AsyncThrowingStream<CapabilityChunk, Error>.Continuation
+    ) async throws {
+        while true {
+            try await ensureLoadedGoverned(
+                path: path, modelID: modelID, modelName: modelName,
+                footprintMB: footprintMB, governor: governor, continuation: continuation)
+            await governor.gate.acquire(producer)
+            if loadedPath == path, container != nil { return }
+            await governor.gate.release(producer)
+        }
+    }
+
+    private func generate(
+        messages: [ChatMessage],
+        params: GenerationParams,
+        continuation: AsyncThrowingStream<CapabilityChunk, Error>.Continuation
+    ) async throws {
+        guard let container else {
+            throw KernelError.runtimeFailed("mlx-swift model not loaded")
+        }
+        guard !messages.isEmpty else {
+            throw KernelError.runtimeFailed("chat produced no messages")
+        }
+
+        let generateParameters = GenerateParameters(
+            maxTokens: params.maxTokens,
+            temperature: params.temperature,
+            topP: params.topP ?? 1.0)
+
+        let clock = ContinuousClock()
+        let started = clock.now
+        var splitter = ThinkSplitter()
+        var promptTokenCount = 0
+        var completionTokenCount = 0
+
+        let stream = try await container.perform { context -> AsyncStream<Generation> in
+            let chat: [Chat.Message] = messages.map { message in
+                switch message.role {
+                case .system: .system(message.content)
+                case .user: .user(message.content)
+                case .assistant: .assistant(message.content)
+                }
+            }
+            let input = try await context.processor.prepare(input: UserInput(chat: chat))
+            return try MLXLMCommon.generate(
+                input: input, parameters: generateParameters, context: context)
+        }
+
+        for await generation in stream {
+            try Task.checkCancellation()
+            switch generation {
+            case .chunk(let text):
+                for piece in splitter.feed(text) {
+                    switch piece {
+                    case .text(let value): continuation.yield(.text(value))
+                    case .thinking(let value): continuation.yield(.thinking(value))
+                    }
+                }
+            case .info(let info):
+                promptTokenCount = info.promptTokenCount
+                completionTokenCount = info.generationTokenCount
+            case .toolCall:
+                break
+            }
+        }
+        for piece in splitter.flush() {
+            switch piece {
+            case .text(let value): continuation.yield(.text(value))
+            case .thinking(let value): continuation.yield(.thinking(value))
+            }
+        }
+
+        let elapsed = clock.now - started
+        continuation.yield(
+            .done(
+                GenerationStats(
+                    promptTokens: promptTokenCount,
+                    completionTokens: completionTokenCount,
+                    durationMs: Int(elapsed.components.seconds) * 1000
+                        + Int(elapsed.components.attoseconds / 1_000_000_000_000_000))))
+    }
+
+    private func ensureLoadedGoverned(
+        path: String,
+        modelID: String,
+        modelName: String,
+        footprintMB: Int?,
+        governor: MemoryGovernor,
+        continuation: AsyncThrowingStream<CapabilityChunk, Error>.Continuation
+    ) async throws {
+        if loadedPath == path, container != nil { return }
+        let verdict = try await governor.admit(
+            modelID: modelID, name: modelName, footprintMB: footprintMB
+        ) { reason in
+            continuation.yield(.status(reason))
+        }
+        if verdict == .tight {
+            continuation.yield(.status("Memory is tight — generation may be slow"))
+        }
+        let producer = GPUProducer.load(modelID: modelID)
+        await governor.gate.acquire(producer)
+        do {
+            if let previousModelID = loadedModelID {
+                unload()
+                await governor.markUnloaded(previousModelID)
+            }
+            try await load(path: path, modelID: modelID)
+            await governor.gate.release(producer)
+        } catch {
+            await governor.gate.release(producer)
+            await governor.markUnloaded(modelID)
+            throw error
+        }
+        await governor.markLoaded(
+            modelID: modelID, name: modelName, footprintMB: footprintMB
+        ) {
+            await MlxSwiftEngine.shared.unloadIfLoaded(path: path)
+        }
+        if let observed = Self.directoryFootprintMB(path: path) {
+            await governor.observeFootprint(modelID, footprintMB: observed)
+        }
+    }
+
+    private func load(path: String, modelID: String) async throws {
+        unload()
+        let directory = URL(fileURLWithPath: path)
+        let configuration = MLXLMCommon.ModelConfiguration(directory: directory)
+        let loaded = try await LLMModelFactory.shared.loadContainer(configuration: configuration)
+        container = loaded
+        loadedPath = path
+        loadedModelID = modelID
+        Self.applyCacheLimit()
+    }
+
+    public func unloadIfLoaded(path: String) {
+        guard loadedPath == path else { return }
+        unload()
+    }
+
+    private func unload() {
+        container = nil
+        loadedPath = nil
+        loadedModelID = nil
+        Self.applyCacheLimit()
+    }
+
+    private static func applyCacheLimit() {
+        MLX.GPU.set(cacheLimit: 32 * 1024 * 1024)
+    }
+
+    static func directoryFootprintMB(path: String) -> Int? {
+        let url = URL(fileURLWithPath: path)
+        guard
+            let enumerator = FileManager.default.enumerator(
+                at: url, includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey])
+        else { return nil }
+        var total = 0
+        for case let entry as URL in enumerator {
+            let values = try? entry.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+            if values?.isRegularFile == true { total += values?.fileSize ?? 0 }
+        }
+        return total / (1 << 20)
+    }
+}

--- a/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftEngine.swift
+++ b/Sources/HedosKernel/Runtimes/MlxSwift/MlxSwiftEngine.swift
@@ -117,14 +117,20 @@ public actor MlxSwiftEngine {
         var completionTokenCount = 0
 
         let stream = try await container.perform { context -> AsyncStream<Generation> in
-            let chat: [Chat.Message] = messages.map { message in
-                switch message.role {
-                case .system: .system(message.content)
-                case .user: .user(message.content)
-                case .assistant: .assistant(message.content)
+            let input: LMInput
+            if context.tokenizer.hasChatTemplate {
+                let chat: [Chat.Message] = messages.map { message in
+                    switch message.role {
+                    case .system: .system(message.content)
+                    case .user: .user(message.content)
+                    case .assistant: .assistant(message.content)
+                    }
                 }
+                input = try await context.processor.prepare(input: UserInput(chat: chat))
+            } else {
+                let rendered = Self.renderChatML(messages)
+                input = try await context.processor.prepare(input: UserInput(prompt: .text(rendered)))
             }
-            let input = try await context.processor.prepare(input: UserInput(chat: chat))
             return try MLXLMCommon.generate(
                 input: input, parameters: generateParameters, context: context)
         }
@@ -212,7 +218,8 @@ public actor MlxSwiftEngine {
         container = loaded
         loadedPath = path
         loadedModelID = modelID
-        Self.applyCacheLimit()
+        let footprintMB = Self.directoryFootprintMB(path: path)
+        Self.applyCacheLimit(footprintMB: footprintMB)
     }
 
     public func unloadIfLoaded(path: String) {
@@ -224,11 +231,28 @@ public actor MlxSwiftEngine {
         container = nil
         loadedPath = nil
         loadedModelID = nil
-        Self.applyCacheLimit()
+        MLX.GPU.clearCache()
     }
 
-    private static func applyCacheLimit() {
-        MLX.GPU.set(cacheLimit: 32 * 1024 * 1024)
+    static func cacheLimit(footprintMB: Int?) -> Int {
+        let gib = 1024 * 1024 * 1024
+        let footprintBytes = (footprintMB ?? 0) * (1 << 20)
+        let weightsBased = max(footprintBytes / 4, gib)
+        let ramBased = min(Int(ProcessInfo.processInfo.physicalMemory) / 8, 8 * gib)
+        return min(weightsBased, ramBased)
+    }
+
+    private static func applyCacheLimit(footprintMB: Int?) {
+        MLX.GPU.set(cacheLimit: cacheLimit(footprintMB: footprintMB))
+    }
+
+    static func renderChatML(_ messages: [ChatMessage]) -> String {
+        var rendered = ""
+        for message in messages {
+            rendered += "<|im_start|>\(message.role.rawValue)\n\(message.content)<|im_end|>\n"
+        }
+        rendered += "<|im_start|>assistant\n"
+        return rendered
     }
 
     static func directoryFootprintMB(path: String) -> Int? {

--- a/Sources/HedosKernel/Runtimes/MlxSwift/ThinkSplitter.swift
+++ b/Sources/HedosKernel/Runtimes/MlxSwift/ThinkSplitter.swift
@@ -1,0 +1,74 @@
+public struct ThinkSplitter: Sendable {
+    public enum Piece: Sendable, Hashable {
+        case text(String)
+        case thinking(String)
+    }
+
+    private enum Mode: Sendable {
+        case text
+        case thinking
+    }
+
+    private static let openTag = "<think>"
+    private static let closeTag = "</think>"
+
+    private var mode: Mode = .text
+    private var buffer = ""
+
+    public init() {}
+
+    public mutating func feed(_ chunk: String) -> [Piece] {
+        buffer += chunk
+        var output: [Piece] = []
+        outer: while true {
+            switch mode {
+            case .text:
+                guard let range = buffer.range(of: Self.openTag) else {
+                    let emit = Self.emittablePrefix(of: buffer, holdingFor: Self.openTag)
+                    if !emit.isEmpty {
+                        output.append(.text(emit))
+                        buffer.removeFirst(emit.count)
+                    }
+                    break outer
+                }
+                let before = String(buffer[buffer.startIndex..<range.lowerBound])
+                if !before.isEmpty { output.append(.text(before)) }
+                buffer.removeSubrange(buffer.startIndex..<range.upperBound)
+                mode = .thinking
+            case .thinking:
+                guard let range = buffer.range(of: Self.closeTag) else {
+                    let emit = Self.emittablePrefix(of: buffer, holdingFor: Self.closeTag)
+                    if !emit.isEmpty {
+                        output.append(.thinking(emit))
+                        buffer.removeFirst(emit.count)
+                    }
+                    break outer
+                }
+                let before = String(buffer[buffer.startIndex..<range.lowerBound])
+                if !before.isEmpty { output.append(.thinking(before)) }
+                buffer.removeSubrange(buffer.startIndex..<range.upperBound)
+                mode = .text
+            }
+        }
+        return output
+    }
+
+    public mutating func flush() -> [Piece] {
+        guard !buffer.isEmpty else { return [] }
+        let piece: Piece = mode == .thinking ? .thinking(buffer) : .text(buffer)
+        buffer = ""
+        return [piece]
+    }
+
+    private static func emittablePrefix(of buffer: String, holdingFor tag: String) -> String {
+        let maxHold = Swift.min(tag.count - 1, buffer.count)
+        guard maxHold > 0 else { return buffer }
+        for length in stride(from: maxHold, through: 1, by: -1) {
+            let suffix = String(buffer.suffix(length))
+            if tag.hasPrefix(suffix) {
+                return String(buffer.dropLast(length))
+            }
+        }
+        return buffer
+    }
+}

--- a/Tests/HedosKernelTests/KernelTests.swift
+++ b/Tests/HedosKernelTests/KernelTests.swift
@@ -10,7 +10,7 @@ import Testing
     #expect(!Kernel.version.isEmpty)
 }
 
-@Test func discoverScansUserConfiguredHFRootAndResolvesMlxLm() async throws {
+@Test func discoverScansUserConfiguredHFRootAndResolvesMlxSwift() async throws {
     let dir = try Fixtures.tempDirectory()
     defer { try? FileManager.default.removeItem(at: dir) }
     let customRoot = dir.appendingPathComponent("custom-hf")
@@ -30,8 +30,9 @@ import Testing
     let records = try await kernel.shelf()
     let record = try #require(records.first { $0.name.contains("Tiny-Chat-4bit") })
     #expect(record.source.kind == .huggingfaceCache)
-    #expect(record.runtime.id == "python:mlx-lm")
-    #expect(record.runtime.tier == .managed)
+    #expect(record.runtime.id == "mlx-swift")
+    #expect(record.runtime.tier == .native)
+    #expect(record.runtime.alternatives.contains("python:mlx-lm"))
     #expect(record.state == .ready)
 }
 

--- a/Tests/HedosKernelTests/Runtimes/MlxSwiftLiveTests.swift
+++ b/Tests/HedosKernelTests/Runtimes/MlxSwiftLiveTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+@testable import HedosKernel
+
+@Test func mlxSwiftLiveGeneratesRealTokens() async throws {
+    guard ProcessInfo.processInfo.environment["HEDOS_MLX_LIVE"] != nil else { return }
+
+    let path =
+        ProcessInfo.processInfo.environment["HEDOS_MLX_MODEL"]
+        ?? NSString(
+            string:
+                "~/models/huggingface/hub/models--mlx-community--Llama-3.2-1B-Instruct-4bit/snapshots/08231374eeacb049a0eade7922910865b8fce912"
+        ).expandingTildeInPath
+
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+        isDirectory.boolValue
+    else { return }
+
+    let governor = MemoryGovernor()
+    let footprintMB = MlxSwiftEngine.directoryFootprintMB(path: path)
+
+    var chunks: [CapabilityChunk] = []
+    let stream = AsyncThrowingStream<CapabilityChunk, Error> { continuation in
+        let task = Task {
+            await MlxSwiftEngine.shared.run(
+                path: path,
+                modelID: "live-mlx",
+                modelName: "Llama-3.2-1B",
+                footprintMB: footprintMB,
+                governor: governor,
+                messages: [ChatMessage(role: .user, content: "Say hello in one short sentence.")],
+                params: .init(maxTokens: 32),
+                continuation: continuation)
+        }
+        continuation.onTermination = { _ in task.cancel() }
+    }
+
+    for try await chunk in stream {
+        chunks.append(chunk)
+    }
+
+    let hasNonEmptyText = chunks.contains { chunk in
+        if case .text(let value) = chunk { return !value.isEmpty }
+        return false
+    }
+    #expect(hasNonEmptyText)
+
+    let stats = chunks.compactMap { chunk -> GenerationStats? in
+        if case .done(let stats) = chunk { return stats }
+        return nil
+    }.first
+
+    let doneStats = try #require(stats)
+    #expect((doneStats.completionTokens ?? 0) > 0)
+    #expect((doneStats.promptTokens ?? 0) > 0)
+}

--- a/Tests/HedosKernelTests/Runtimes/MlxSwiftTests.swift
+++ b/Tests/HedosKernelTests/Runtimes/MlxSwiftTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import Testing
+
+@testable import HedosKernel
+
+private func mlxTextRecord() -> ModelRecord {
+    ModelRecord(
+        name: "Llama-3.2-1B-Instruct-4bit",
+        modality: .text,
+        capabilities: [.chat, .complete],
+        source: ModelSource(
+            kind: .huggingfaceCache,
+            path: "~/models/huggingface/hub/models--mlx-community--Llama-3.2-1B-Instruct-4bit",
+            repo: "mlx-community/Llama-3.2-1B-Instruct-4bit"),
+        runtime: RuntimeRef(
+            id: "mlx-swift",
+            resolved: .auto,
+            tier: .native),
+        execution: .stream,
+        footprintMB: 700,
+        state: .ready,
+        registeredAt: Date(timeIntervalSince1970: 1_750_000_000))
+}
+
+@Test func mlxSwiftCanServeChatAndCompleteOnly() {
+    let adapter = MlxSwiftAdapter()
+    let record = mlxTextRecord()
+    #expect(adapter.canServe(record, .chat))
+    #expect(adapter.canServe(record, .complete))
+    #expect(!adapter.canServe(record, .speak))
+    #expect(!adapter.canServe(record, .transcribe))
+    var other = record
+    other.runtime.id = "python:mlx-lm"
+    #expect(!adapter.canServe(other, .chat))
+}
+
+@Test func mlxSwiftAdapterBidMatrix() {
+    let adapter = MlxSwiftAdapter()
+    let record = mlxTextRecord()
+
+    let mlxText = IdentifiedModel(
+        format: .mlxSafetensors, modality: .text, capabilities: [.chat, .complete],
+        execution: .stream)
+    let bid = adapter.bid(record, mlxText)
+    #expect(bid?.tier == .native)
+    #expect(bid?.preference == 15)
+
+    let plainText = IdentifiedModel(
+        format: .safetensors, modality: .text, capabilities: [.chat, .complete],
+        execution: .stream)
+    let mlxSpeech = IdentifiedModel(
+        format: .mlxSafetensors, modality: .speech, capabilities: [.speak], execution: .stream)
+    let ggufText = IdentifiedModel(
+        format: .gguf, modality: .text, capabilities: [.chat, .complete], execution: .stream)
+    let mlxTextNoChat = IdentifiedModel(
+        format: .mlxSafetensors, modality: .text, capabilities: [.complete], execution: .stream)
+    #expect(adapter.bid(record, plainText) == nil)
+    #expect(adapter.bid(record, mlxSpeech) == nil)
+    #expect(adapter.bid(record, ggufText) == nil)
+    #expect(adapter.bid(record, mlxTextNoChat) == nil)
+}
+
+@Test func mlxSwiftBidOutranksMlxLmSidecar() throws {
+    let mlxSwift = MlxSwiftAdapter()
+    let mlxLm = MlxLmAdapter()
+    let record = mlxTextRecord()
+    let identified = IdentifiedModel(
+        format: .mlxSafetensors, modality: .text, capabilities: [.chat, .complete],
+        execution: .stream)
+    let swiftBid = try #require(mlxSwift.bid(record, identified))
+    let lmBid = try #require(mlxLm.bid(record, identified))
+    #expect(swiftBid.preference < lmBid.preference)
+}
+
+@Test func mlxSwiftAdapterReadsMergedParams() {
+    let payload: [String: JSONValue] = [
+        "temperature": .double(0.2),
+        "top_p": .double(0.85),
+        "max_tokens": .int(512),
+    ]
+    let params = MlxSwiftAdapter.params(from: payload)
+    #expect(params.temperature == 0.2)
+    #expect(params.topP == 0.85)
+    #expect(params.maxTokens == 512)
+}
+
+@Test func mlxSwiftAdapterFallsBackWhenParamsAbsent() {
+    let params = MlxSwiftAdapter.params(from: [:])
+    #expect(params.temperature == 0.7)
+    #expect(params.topP == nil)
+    #expect(params.maxTokens == 2048)
+
+    let zeroMax = MlxSwiftAdapter.params(from: ["max_tokens": .int(0)])
+    #expect(zeroMax.maxTokens == 2048)
+}
+
+@Test func thinkSplitterClassifiesASingleCompleteBlockInOnePiece() {
+    var splitter = ThinkSplitter()
+    let pieces = splitter.feed("before <think>pondering</think> after")
+    let flushed = splitter.flush()
+    let all = pieces + flushed
+    #expect(all == [
+        .text("before "),
+        .thinking("pondering"),
+        .text(" after"),
+    ])
+}
+
+@Test func thinkSplitterHandlesOpenTagSplitAcrossPieces() {
+    var splitter = ThinkSplitter()
+    var all: [ThinkSplitter.Piece] = []
+    all += splitter.feed("hello <th")
+    all += splitter.feed("ink>wondering</think> world")
+    all += splitter.flush()
+    #expect(all == [
+        .text("hello "),
+        .thinking("wondering"),
+        .text(" world"),
+    ])
+}
+
+@Test func thinkSplitterHandlesCloseTagSplitAcrossPieces() {
+    var splitter = ThinkSplitter()
+    var all: [ThinkSplitter.Piece] = []
+    all += splitter.feed("<think>musing</th")
+    all += splitter.feed("ink> done")
+    all += splitter.flush()
+    #expect(all == [
+        .thinking("musing"),
+        .text(" done"),
+    ])
+}
+
+@Test func thinkSplitterHandlesThinkingContentSplitAcrossManyPieces() {
+    var splitter = ThinkSplitter()
+    var all: [ThinkSplitter.Piece] = []
+    for chunk in ["<think>", "step one, ", "step two, ", "step three", "</think>", "answer"] {
+        all += splitter.feed(chunk)
+    }
+    all += splitter.flush()
+    let thinking = all.compactMap { piece -> String? in
+        if case .thinking(let value) = piece { return value }
+        return nil
+    }.joined()
+    let text = all.compactMap { piece -> String? in
+        if case .text(let value) = piece { return value }
+        return nil
+    }.joined()
+    #expect(thinking == "step one, step two, step three")
+    #expect(text == "answer")
+}
+
+@Test func thinkSplitterPassesThroughPlainTextUnchanged() {
+    var splitter = ThinkSplitter()
+    var all: [ThinkSplitter.Piece] = []
+    all += splitter.feed("no tags here, ")
+    all += splitter.feed("just plain text.")
+    all += splitter.flush()
+    let joined = all.compactMap { piece -> String? in
+        if case .text(let value) = piece { return value }
+        return nil
+    }.joined()
+    #expect(joined == "no tags here, just plain text.")
+    #expect(!all.contains { if case .thinking = $0 { return true } else { return false } })
+}
+
+@Test func thinkSplitterRoundTripsMultipleBlocksMinusTags() {
+    var splitter = ThinkSplitter()
+    let input = "a<think>b</think>c<think>d</think>e"
+    var all: [ThinkSplitter.Piece] = []
+    for character in input {
+        all += splitter.feed(String(character))
+    }
+    all += splitter.flush()
+    let roundTripped = all.map { piece -> String in
+        switch piece {
+        case .text(let value): value
+        case .thinking(let value): value
+        }
+    }.joined()
+    #expect(roundTripped == "abcde")
+    #expect(all == [
+        .text("a"),
+        .thinking("b"),
+        .text("c"),
+        .thinking("d"),
+        .text("e"),
+    ])
+}
+
+@Test func thinkSplitterFlushEmitsUnterminatedThinkingBuffer() {
+    var splitter = ThinkSplitter()
+    var all: [ThinkSplitter.Piece] = []
+    all += splitter.feed("before <think>never closes")
+    all += splitter.flush()
+    #expect(all == [
+        .text("before "),
+        .thinking("never closes"),
+    ])
+}

--- a/scripts/build_app.sh
+++ b/scripts/build_app.sh
@@ -28,6 +28,30 @@ else
 fi
 cp Sources/Hedos/Resources/Hedos.icns "$APP/Contents/Resources/Hedos.icns"
 
+MLX_VERSION=$(jq -r '.pins[] | select(.identity=="mlx-swift") | .state.version' Package.resolved)
+if [ -z "$MLX_VERSION" ] || [ "$MLX_VERSION" = "null" ]; then
+    echo "error: could not resolve mlx-swift version from Package.resolved" >&2
+    exit 1
+fi
+METALLIB_CACHE="dist/.mlx-metallib-cache/$MLX_VERSION"
+METALLIB="$METALLIB_CACHE/mlx.metallib"
+if [ ! -f "$METALLIB" ]; then
+    echo "fetching mlx==$MLX_VERSION metallib via uv"
+    VENV=$(mktemp -d -t hedos-mlx-metallib)
+    uv venv "$VENV/venv" --python 3.12 >/dev/null
+    uv pip install --python "$VENV/venv/bin/python" "mlx==$MLX_VERSION" >/dev/null
+    FOUND=$(find "$VENV/venv" -path '*/mlx/lib/mlx.metallib' | head -1)
+    if [ -z "$FOUND" ]; then
+        echo "error: mlx==$MLX_VERSION did not provide mlx.metallib" >&2
+        rm -rf "$VENV"
+        exit 1
+    fi
+    mkdir -p "$METALLIB_CACHE"
+    cp "$FOUND" "$METALLIB"
+    rm -rf "$VENV"
+fi
+cp "$METALLIB" "$APP/Contents/MacOS/mlx.metallib"
+
 cat > "$APP/Contents/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -81,6 +105,7 @@ sign_bundle() {
         [ -e "$framework" ] || continue
         codesign --force "$@" "$framework"
     done
+    codesign --force "$@" "$APP/Contents/MacOS/mlx.metallib"
     codesign --force "$@" --entitlements "$ENTITLEMENTS" "$APP"
 }
 


### PR DESCRIPTION
This adds a native, in-process MLX text runtime so MLX-format models resolve `native` instead of going through the `python:mlx-lm` sidecar.`mlx-swift (in-proc)` is the top-ranked text runtime, and running it in process removes the venv/spawn/IPC hop while letting us fix three sidecar caveats: honest context/KV stats, `<think>`/`</think>` stream splitting, and
per-runtime keep-warm.

The new `MlxSwiftAdapter` bids `.native` at preference 15 on the `(.mlxSafetensors, .text, .chat)` triple. Since lower preference wins and the sidecar bids 40, `mlx-swift` takes the model and `python:mlx-lm` falls back to being its alternative — no change to `MlxLmAdapter` or the resolver. Under the hood, `MlxSwiftEngine` is a singleton actor mirroring `LlamaEngine`: it loads only fully-present local files (`ModelConfiguration(directory:)`, no repo-id path, so weights are never downloaded or moved), drives the memory-governor triad (lease → admission → GPU gate), applies a footprint-aware GPU cache limit, cancels cooperatively, and keeps the model warm with idle-unload. A small pure `ThinkSplitter` classifies thinking vs. text output across chunk-split tags.

Because a bare `swift build` doesn't produce MLX's Metal shader library, `scripts/build_app.sh` now packages a version-matched `mlx.metallib` into `Hedos.app` — the version is derived from `Package.resolved`, fetched via `uv` and cached, copied next to the executable, and signed so the bundle passes `codesign --verify --deep --strict`. Without it the shipped app would crash the moment you chatted with an MLX model